### PR TITLE
Create gulp build command to run build once and exit without watching…

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,4 @@
-const { src, watch, dest } = require('gulp');
+const { src, watch, dest, parallel } = require('gulp');
 var sass = require('gulp-sass');
 var notify = require('gulp-notify');
 
@@ -13,8 +13,14 @@ function compileSCSS(origDir, message = 'Styles processed', destDir = '') {
     .pipe(notify({ message: message, onLast: true }));
 }
 
+const compileScssDir = () => compileSCSS('scss', 'Branding styles processed', 'css');
+const compileCruorgDir = () => compileSCSS('cruorg', 'Cru.org styles processed');
+
+// Build both directories once
+exports.build = parallel(compileScssDir, compileCruorgDir);
+
 // Watch and compile everything
 exports.default = function() {
-  watch(`./scss/**/*.scss`, () => compileSCSS('scss', 'Branding styles processed', 'css'));
-  watch(`./cruorg/**/*.scss`, () => compileSCSS('cruorg', 'Cru.org styles processed'));
+  watch(`./scss/**/*.scss`, compileScssDir);
+  watch(`./cruorg/**/*.scss`, compileCruorgDir);
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Designs for use on cru.org and other Cru digital properties utilizing official branding guidelines.",
   "main": "index.js",
   "scripts": {
-    "build": "gulp",
+    "start": "gulp",
+    "build": "gulp build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",


### PR DESCRIPTION
… files

I finally discovered that we were watching for file changes during the gulp build so the command was never exiting. Github Actions just let it run for 4 hours until I canceled it https://github.com/CruGlobal/cru-branding-submodule/runs/2741932697?check_suite_focus=true#step:5:12.

I added an additional `gulp build` command to just build the files once. I also updated `package.json` scripts so you can use `npm start` and `npm run build` as aliases for these commands.

Let me know if this looks good and feel free to merge in the morning.

To trigger the build again with the same version, I think you need to delete the release and recreate it (since it hasn't make it to npm yet, doesn't really matter what happens with the versions). Or you can just make a new release with a different version number.